### PR TITLE
[codex] Fix Firebase build initialization

### DIFF
--- a/src/app/api/notifications/mass-notification/route.ts
+++ b/src/app/api/notifications/mass-notification/route.ts
@@ -1,6 +1,4 @@
 import { NextRequest, NextResponse } from 'next/server'
-import webpush, { WebPushError } from 'web-push'
-import { messaging } from 'firebase-admin'
 import { sendNotification } from '@/server/notifications'
 import prisma from '@/server/db'
 import { withLogging, logger } from '@/server/logger'

--- a/src/server/firebase.ts
+++ b/src/server/firebase.ts
@@ -1,11 +1,34 @@
-import admin, { ServiceAccount } from 'firebase-admin'
+import { App, cert, getApps, initializeApp } from 'firebase-admin/app'
+import { getMessaging } from 'firebase-admin/messaging'
 
-const serviceAccount = process.env.GOOGLE_SERVICES_JSON ? JSON.parse(process.env.GOOGLE_SERVICES_JSON) : null
+function getServiceAccount() {
+  const rawServiceAccount = process.env.GOOGLE_SERVICES_JSON
 
-if (!admin.apps.length && serviceAccount) {
-  admin.initializeApp({
-    credential: admin.credential.cert(serviceAccount as ServiceAccount),
+  if (!rawServiceAccount) {
+    return null
+  }
+
+  return JSON.parse(rawServiceAccount)
+}
+
+export function getFirebaseApp(): App {
+  const existingApp = getApps()[0]
+
+  if (existingApp) {
+    return existingApp
+  }
+
+  const serviceAccount = getServiceAccount()
+
+  if (!serviceAccount) {
+    throw new Error('Firebase Admin is not configured. Set GOOGLE_SERVICES_JSON before using FCM.')
+  }
+
+  return initializeApp({
+    credential: cert(serviceAccount),
   })
 }
 
-export const messaging = admin.messaging()
+export function getFirebaseMessaging() {
+  return getMessaging(getFirebaseApp())
+}

--- a/src/server/notifications.ts
+++ b/src/server/notifications.ts
@@ -1,17 +1,23 @@
 import webpush, { WebPushError } from 'web-push'
-import { messaging } from '@/server/firebase'
+import { getFirebaseMessaging } from '@/server/firebase'
 //import { Subscription } from '@prisma/client'
 //import { JsonValue } from '@prisma/client/runtime/library'
 import prisma from '@/server/db'
 import { logger } from '@/server/logger'
 import { Prisma, Subscription } from '../generated/prisma/client'
 
-// Initialize VAPID keys for web push notifications
-webpush.setVapidDetails(
-  'mailto:your-email@example.com',
-  process.env.NEXT_PUBLIC_VAPID_PUBLIC_KEY!,
-  process.env.VAPID_PRIVATE_KEY!
-)
+function configureWebPush() {
+  const publicKey = process.env.NEXT_PUBLIC_VAPID_PUBLIC_KEY
+  const privateKey = process.env.VAPID_PRIVATE_KEY
+
+  if (!publicKey || !privateKey) {
+    throw new Error(
+      'Web push is not configured. Set NEXT_PUBLIC_VAPID_PUBLIC_KEY and VAPID_PRIVATE_KEY.'
+    )
+  }
+
+  webpush.setVapidDetails('mailto:your-email@example.com', publicKey, privateKey)
+}
 
 /**
  * The payload for the notification, including title, body, url, icon, and badge.
@@ -33,6 +39,8 @@ export async function sendNotification(
   try {
     logger.info('Sending notification to subscription:', subscription)
     if (subscription.type === 'web') {
+      configureWebPush()
+
       if (!isWebKeys(subscription.keys)) {
         throw new Error(`Invalid keys for web subscription: ${JSON.stringify(subscription.keys)}`)
       }
@@ -56,6 +64,7 @@ export async function sendNotification(
       if (!isFcmKeys(subscription.keys)) {
         throw new Error(`Invalid keys for FCM subscription: ${JSON.stringify(subscription.keys)}`)
       }
+      const messaging = getFirebaseMessaging()
       const fcmMessage = {
         notification: {
           title: notificationPayload.title,


### PR DESCRIPTION
<!-- GH-PAGES-PREVIEW:START -->
🌐 **Preview:** [https://codebuilder.org/preview/fix-firebase-build-init/](https://codebuilder.org/preview/fix-firebase-build-init/)
<sub>Deployed from `8ba71be`</sub>
<!-- GH-PAGES-PREVIEW:END -->

## What changed
- refactored Firebase Admin setup to initialize lazily instead of at module import time
- moved web-push VAPID setup into the notification send path so build-time imports do not require notification secrets
- removed unused `firebase-admin` and `web-push` imports from the mass notification route

## Why
Next.js was importing the notification route during build-time page data collection. That pulled in Firebase Admin code that called `admin.messaging()` before any app had been initialized, which caused the build to fail with `app/no-app`.

## Impact
- Cloudflare/CI builds should no longer fail when Firebase Admin credentials are absent during route import
- FCM and web-push setup still happen when notification sends actually run

## Validation
- `pnpm exec tsc --noEmit`
- local `git push -u origin fix/firebase-build-init`