### PR TITLE
[codex] Update workflows and fix Firebase runtime build initialization

### DIFF
--- a/.github/workflows/cleanup-gh-pages-preview.yml
+++ b/.github/workflows/cleanup-gh-pages-preview.yml
@@ -14,7 +14,7 @@ jobs:
 
     steps:
       - name: 🔍 Checkout gh-pages branch
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: gh-pages
           fetch-depth: 1

--- a/.github/workflows/cloudflare-pages-runtime.yml
+++ b/.github/workflows/cloudflare-pages-runtime.yml
@@ -21,7 +21,7 @@ jobs:
 
     steps:
       - name: 🔍 Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: 🔒 Verify Google services secret exists
         run: |
@@ -33,9 +33,13 @@ jobs:
       - name: 📁 Set Google services environment variable
         run: |
           echo "$GOOGLE_SERVICES_JSON_BASE64" | base64 -d > /tmp/google-services.json
-          echo "GOOGLE_SERVICES_JSON<<EOF" >> $GITHUB_ENV
-          cat /tmp/google-services.json >> $GITHUB_ENV
-          echo "EOF" >> $GITHUB_ENV
+
+          if ! jq -c . /tmp/google-services.json > /tmp/google-services.compact.json; then
+            echo "❌ GOOGLE_SERVICES_JSON_BASE64 did not decode to valid JSON"
+            exit 1
+          fi
+
+          printf 'GOOGLE_SERVICES_JSON=%s\n' "$(cat /tmp/google-services.compact.json)" >> "$GITHUB_ENV"
         env:
           GOOGLE_SERVICES_JSON_BASE64: ${{ secrets.GOOGLE_SERVICES_JSON_BASE64 }}
 

--- a/.github/workflows/cloudflare-pages.yml
+++ b/.github/workflows/cloudflare-pages.yml
@@ -21,7 +21,7 @@ jobs:
 
     steps:
       - name: 🔍 Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: 📦 Install pnpm
         run: npm install -g pnpm@10

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -13,7 +13,7 @@ jobs:
 
     steps:
       - name: '🔍 Checkout Code'
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           submodules: 'recursive'
 

--- a/.github/workflows/nextjs-static-gh-pages.yml
+++ b/.github/workflows/nextjs-static-gh-pages.yml
@@ -24,7 +24,7 @@ jobs:
 
     steps:
       - name: 🔍 Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
## What changed
- fixed Firebase Admin initialization so notification-related imports do not crash Next.js builds at module evaluation time
- moved web-push configuration into the send path instead of doing it at import time
- updated workflow files to use `actions/checkout@v5`
- updated the Cloudflare Pages runtime workflow to write `GOOGLE_SERVICES_JSON` to `$GITHUB_ENV` as compact single-line JSON instead of a multiline heredoc
- included the current branch’s additional page, video, notification, and workflow changes now present at `fix/firebase-build-init`

## Why
The branch fixes the original runtime build failure caused by Firebase Admin being accessed before initialization, and it also fixes the Cloudflare runtime workflow issue where an env-file heredoc could fail with `Matching delimiter not found 'EOF'`.

## Impact
- runtime builds should stop failing on import-time Firebase initialization
- the Cloudflare Pages runtime workflow should stop failing while setting `GOOGLE_SERVICES_JSON`
- GitHub Actions checkout steps move off the deprecated Node 20 runtime path

## Validation
- `pnpm exec tsc --noEmit`
- branch head pushed to `origin/fix/firebase-build-init`

## Notes
- untracked local files containing encoded or unencoded secret material were not included in this PR