### PR TITLE
[codex] Fix Prisma submodule checkout in runtime workflow

### DIFF
--- a/.github/workflows/cloudflare-pages-runtime.yml
+++ b/.github/workflows/cloudflare-pages-runtime.yml
@@ -22,6 +22,8 @@ jobs:
     steps:
       - name: 🔍 Checkout repository
         uses: actions/checkout@v5
+        with:
+          submodules: 'recursive'
 
       - name: 🔒 Verify Google services secret exists
         run: |


### PR DESCRIPTION
<!-- GH-PAGES-PREVIEW:START -->
🌐 **Preview:** [https://codebuilder.org/preview/fix-runtime-prisma-submodule-checkout/](https://codebuilder.org/preview/fix-runtime-prisma-submodule-checkout/)
<sub>Deployed from `ef48a4f`</sub>
<!-- GH-PAGES-PREVIEW:END -->

## What changed
- updated the Cloudflare Pages runtime workflow checkout step to fetch git submodules recursively

## Why
The runtime workflow runs `pnpm prisma generate`, and Prisma is configured to load `prisma/schema.prisma` from the `prisma` git submodule. Without submodule checkout, CI does not have that directory populated, so the workflow fails with:

`Could not load schema from /home/runner/work/codebuilder-frontend/codebuilder-frontend/prisma/schema.prisma`

## Impact
- the runtime workflow should have the `prisma` submodule available during CI
- `pnpm prisma generate` should stop failing due to the missing schema path

## Validation
- verified `.gitmodules` defines `prisma` as a submodule
- matched the existing `submodules: 'recursive'` checkout pattern already used in `deploy.yml`